### PR TITLE
S3를 이용한 이미지 추가 및 서비스 보안키 등록

### DIFF
--- a/wasin/build.gradle
+++ b/wasin/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'com.jcraft:jsch:0.1.55'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
@@ -44,6 +46,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+    testImplementation "org.testcontainers:localstack:1.16.3"
 
     // third-party
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.4.0'

--- a/wasin/src/main/java/com/wasin/backend/_core/config/AwsS3Config.java
+++ b/wasin/src/main/java/com/wasin/backend/_core/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.wasin.backend._core.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+}

--- a/wasin/src/main/java/com/wasin/backend/_core/exception/BaseException.java
+++ b/wasin/src/main/java/com/wasin/backend/_core/exception/BaseException.java
@@ -45,6 +45,7 @@ public enum BaseException {
     COMPANY_NOT_FOUND("회사가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     COMPANY_USER_NOT_FOUND("해당 관리자는 회사에 속해있지 않습니다.", HttpStatus.NOT_FOUND),
     NOT_SAME_COMPANY("일반 관리자와 최종 관리자의 회사가 다릅니다.", HttpStatus.BAD_REQUEST),
+    WRONG_WASIN_SERVICE_KEY("와신 상담의 서비스키가 잘못되었습니다.", HttpStatus.BAD_REQUEST),
 
     ;
 

--- a/wasin/src/main/java/com/wasin/backend/_core/exception/BaseException.java
+++ b/wasin/src/main/java/com/wasin/backend/_core/exception/BaseException.java
@@ -16,6 +16,7 @@ public enum BaseException {
     UNEXPECTED_EXCEPTION("예상치 못한 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     MESSAGE_NOT_READABLE("메시지를 읽을 수 없습니다.", HttpStatus.BAD_REQUEST),
     COMPANY_OPEN_API_FAIL("Open API를 이용하여 회사 목록을 불러오는데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AWS_IMAGE_FAIL("aws에 이미지를 올리는 것을 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 유저
     USER_NOT_FOUND("서비스를 탈퇴했거나 가입하지 않은 유저의 요청입니다.", HttpStatus.NOT_FOUND),

--- a/wasin/src/main/java/com/wasin/backend/_core/util/AwsFileUtil.java
+++ b/wasin/src/main/java/com/wasin/backend/_core/util/AwsFileUtil.java
@@ -1,0 +1,45 @@
+package com.wasin.backend._core.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.wasin.backend._core.exception.BaseException;
+import com.wasin.backend._core.exception.error.ServerException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class AwsFileUtil {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    public void upload(MultipartFile file) {
+        String fileName =  UUID.randomUUID() + file.getName();
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try {
+            amazonS3Client.putObject(
+                    new PutObjectRequest(bucket, fileName, file.getInputStream(), objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch(IOException e) {
+            throw new ServerException(BaseException.AWS_IMAGE_FAIL);
+        }
+    }
+
+}

--- a/wasin/src/main/java/com/wasin/backend/controller/CompanyController.java
+++ b/wasin/src/main/java/com/wasin/backend/controller/CompanyController.java
@@ -5,11 +5,13 @@ import com.wasin.backend._core.util.ApiUtils;
 import com.wasin.backend.domain.dto.CompanyRequest;
 import com.wasin.backend.domain.dto.CompanyResponse;
 import com.wasin.backend.service.CompanyService;
+import jakarta.mail.Multipart;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @RestController
@@ -35,9 +37,10 @@ public class CompanyController {
 
     // 오픈 API 내 회사 등록
     @PostMapping("/open-api")
-    public ResponseEntity<?> saveCompanyByOpenAPI(@RequestBody @Valid CompanyRequest.CompanyByOpenAPI request,
+    public ResponseEntity<?> saveCompanyByOpenAPI(@RequestPart(value = "data") @Valid CompanyRequest.CompanyDTO request,
+                                                  @RequestPart(value = "file") MultipartFile file,
                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
-        companyService.saveCompanyByOpenAPI(request, userDetails.getUser());
+        companyService.saveCompanyByOpenAPI(request, file, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 

--- a/wasin/src/main/java/com/wasin/backend/domain/dto/CompanyRequest.java
+++ b/wasin/src/main/java/com/wasin/backend/domain/dto/CompanyRequest.java
@@ -6,6 +6,16 @@ import jakarta.validation.constraints.Size;
 
 public class CompanyRequest {
 
+    public record CompanyDTO(
+
+            @NotEmpty(message = "서비스키는 비어있으면 안됩니다.")
+            @Size(max = 255, message = "서비스키는 255자 이내여야 합니다.")
+            String serviceKey,
+
+            CompanyByOpenAPI company
+    ) {
+    }
+
     public record CompanyByOpenAPI(
             @NotEmpty(message = "회사 companyFssId는 비어있으면 안됩니다.")
             @Size(max = 255, message = "회사 companyFssId는 255자 이내여야 합니다.")

--- a/wasin/src/main/java/com/wasin/backend/domain/validation/CompanyValidation.java
+++ b/wasin/src/main/java/com/wasin/backend/domain/validation/CompanyValidation.java
@@ -2,18 +2,34 @@ package com.wasin.backend.domain.validation;
 
 import com.wasin.backend._core.exception.BaseException;
 import com.wasin.backend._core.exception.error.BadRequestException;
+import com.wasin.backend.domain.dto.CompanyRequest;
 import com.wasin.backend.repository.CompanyRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class CompanyValidation {
 
+    @Value("${security.service-key}")
+    private String serviceKey;
+
     private final CompanyRepository companyRepository;
 
-    public void checkIfCompanyExist(String fssId) {
-        if (companyRepository.findByFssId(fssId).isPresent()) {
+    public void checkCompanyByOpenAPI(CompanyRequest.CompanyDTO companyDTO) {
+        checkServiceKey(companyDTO.serviceKey());
+        checkCompanyNotExist(companyDTO);
+    }
+
+    private void checkServiceKey(String key) {
+        if (!serviceKey.equals(key)) {
+            throw new BadRequestException(BaseException.WRONG_WASIN_SERVICE_KEY);
+        }
+    }
+
+    private void checkCompanyNotExist(CompanyRequest.CompanyDTO companyDTO) {
+        if (companyRepository.findByFssId(companyDTO.company().companyFssId()).isPresent()) {
             throw new BadRequestException(BaseException.COMPANY_ALREADY_EXIST);
         }
     }

--- a/wasin/src/main/java/com/wasin/backend/service/CompanyService.java
+++ b/wasin/src/main/java/com/wasin/backend/service/CompanyService.java
@@ -3,13 +3,14 @@ package com.wasin.backend.service;
 import com.wasin.backend.domain.dto.CompanyRequest;
 import com.wasin.backend.domain.dto.CompanyResponse;
 import com.wasin.backend.domain.entity.User;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface CompanyService {
     CompanyResponse.OpenAPIList findAllCompanyByOpenAPI(String name, Long page);
 
     CompanyResponse.DBList findAllCompanyByDB();
 
-    void saveCompanyByOpenAPI(CompanyRequest.CompanyByOpenAPI request, User user);
+    void saveCompanyByOpenAPI(CompanyRequest.CompanyDTO request, MultipartFile file, User user);
 
     void saveCompanyByDB(CompanyRequest.CompanyByDB request, User user);
 }

--- a/wasin/src/main/java/com/wasin/backend/service/impl/CompanyServiceImpl.java
+++ b/wasin/src/main/java/com/wasin/backend/service/impl/CompanyServiceImpl.java
@@ -3,6 +3,7 @@ package com.wasin.backend.service.impl;
 import com.wasin.backend._core.exception.BaseException;
 import com.wasin.backend._core.exception.error.BadRequestException;
 import com.wasin.backend._core.exception.error.NotFoundException;
+import com.wasin.backend._core.util.AwsFileUtil;
 import com.wasin.backend._core.util.WebApiUtil;
 import com.wasin.backend.domain.dto.CompanyDTO;
 import com.wasin.backend.domain.dto.CompanyRequest;
@@ -17,6 +18,7 @@ import com.wasin.backend.service.CompanyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +33,7 @@ public class CompanyServiceImpl implements CompanyService {
     private final CompanyValidation companyValidation;
     private final CompanyMapper companyMapper;
     private final UserJPARepository userJPARepository;
+    private final AwsFileUtil awsFileUtil;
 
     public CompanyResponse.OpenAPIList findAllCompanyByOpenAPI(String name, Long page) {
         CompanyDTO.ResponseValue companyList = webApiUtil.getCompanyList(name, page);
@@ -48,9 +51,10 @@ public class CompanyServiceImpl implements CompanyService {
     }
 
     @Transactional
-    public void saveCompanyByOpenAPI(CompanyRequest.CompanyByOpenAPI request, User user) {
-        companyValidation.checkIfCompanyExist(request.companyFssId());
-        Company company = companyMapper.openAPIDTOToCompany(request);
+    public void saveCompanyByOpenAPI(CompanyRequest.CompanyDTO request, MultipartFile file, User user) {
+        companyValidation.checkCompanyByOpenAPI(request);
+        Company company = companyMapper.openAPIDTOToCompany(request.company());
+        awsFileUtil.upload(file);
         companyRepository.save(company);
     }
 

--- a/wasin/src/main/resources/application-dev.yml
+++ b/wasin/src/main/resources/application-dev.yml
@@ -17,6 +17,7 @@ security:
   open-api:
     secret-key: ${OPEN_API_SECRET_KEY}
     token: ${OPEN_API_TOKEN}
+  service-key: ${WASIN_SERVICE_KEY}
 
 spring:
   datasource:
@@ -55,3 +56,13 @@ kwon:
 jang:
   header: ${JANG_HEADER}
   url: ${JANG_URL}
+
+cloud:
+  aws:
+    s3:
+      bucket: wasin-buckect
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_ACCESS_SECRET_KEY}

--- a/wasin/src/main/resources/application-test.yml
+++ b/wasin/src/main/resources/application-test.yml
@@ -17,8 +17,11 @@ security:
   open-api:
     secret-key: ${OPEN_API_SECRET_KEY}
     token: ${OPEN_API_TOKEN}
+  service-key: ${WASIN_SERVICE_KEY}
 
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8.0:///test_container_test
@@ -52,3 +55,13 @@ kwon:
 jang:
   header: ${JANG_HEADER}
   url: ${JANG_URL}
+
+cloud:
+  aws:
+    s3:
+      bucket: wasin-buckect
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_ACCESS_SECRET_KEY}

--- a/wasin/src/test/java/com/wasin/backend/config/S3MockConfig.java
+++ b/wasin/src/test/java/com/wasin/backend/config/S3MockConfig.java
@@ -1,0 +1,21 @@
+package com.wasin.backend.config;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.wasin.backend._core.config.AwsS3Config;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Profile("test")
+@TestConfiguration
+public class S3MockConfig extends AwsS3Config {
+
+    @Override
+    @Bean(name = "new-amazonS3")
+    @Primary
+    public AmazonS3Client amazonS3Client(){
+        return Mockito.mock(AmazonS3Client.class);
+    }
+}

--- a/wasin/src/test/java/com/wasin/backend/util/TestModule.java
+++ b/wasin/src/test/java/com/wasin/backend/util/TestModule.java
@@ -1,21 +1,19 @@
 package com.wasin.backend.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wasin.backend.config.S3MockConfig;
 import com.wasin.backend._core.exception.BaseException;
 import com.wasin.backend._core.exception.error.NotFoundException;
 import com.wasin.backend._core.security.JWTProvider;
 import com.wasin.backend.domain.dto.UserResponse;
 import com.wasin.backend.domain.entity.User;
-import com.wasin.backend.domain.entity.enums.Role;
-import com.wasin.backend.domain.entity.enums.Status;
-import com.wasin.backend.dummy.DummyEntity;
 import com.wasin.backend.repository.UserJPARepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -31,6 +29,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Sql("classpath:db/teardown.sql")
 @AutoConfigureMockMvc
 @Testcontainers
+@Import(S3MockConfig.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 public class TestModule {
 


### PR DESCRIPTION
# 변경내역
- S3를 이용한 이미지 추가 구현
- 슈퍼 관리자가 회사 등록할 때 회사랑 이미지랑 보안키를 등록하도록 변경
- 테스트할 때 자원을 아끼기 위해 Mock 사용

# 스크린샷

# 비고

# 연관이슈

close #9 